### PR TITLE
Update aws ses to latest version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [joda-time "2.8"]
-                 [com.amazonaws/aws-java-sdk-ses "1.9.39" :exclusions [joda-time]]
+                 [com.amazonaws/aws-java-sdk-ses "1.11.192" :exclusions [joda-time]]
                  [com.taoensso/encore "1.34.0"]]
   :profiles {:dev {:dependencies [[im.chit/vinyasa "0.3.4"]]}
              :test {:dependencies [[expectations "2.1.2"]]


### PR DESCRIPTION
With the current version I get "java.lang.IllegalStateException: Socket not created by this factory".
Updating to the latest ses sdk seems to fix it.
Seems to be a ses sdk issue : https://github.com/aws/aws-sdk-java/issues/1032